### PR TITLE
Bugfix: Return 0 if value is not an array

### DIFF
--- a/Classes/Model/Repeatable.php
+++ b/Classes/Model/Repeatable.php
@@ -130,7 +130,11 @@ class Repeatable implements \Iterator, \JsonSerializable, \Countable, \ArrayAcce
     }
 
     public function count(): int{
-        return count($this->toArray());
+        $value = $this->toArray();
+        if (!is_array($value)) {
+            return 0;
+        }
+        return count($value);
     }
 
     /**


### PR DESCRIPTION
In certain circumstances it is possible that the `defaultValue` is not set correctly. This fix prevents that the page can no longer be rendered